### PR TITLE
Depend on python3-dnf, not dnf

### DIFF
--- a/rpm/dnf-plugin-diff.spec
+++ b/rpm/dnf-plugin-diff.spec
@@ -13,7 +13,7 @@ Source0:        https://github.com/praiskup/%{name}/archive/v%{version}/%{name}-
 BuildRequires:  python3-devel
 
 Requires:       cpio
-Requires:       dnf
+Requires:       python3-dnf
 Requires:       file
 
 Provides:       dnf-command(diff) = %version


### PR DESCRIPTION
DNF5 is replacing DNF in Fedora 39+, so packages should no longer depend on the `dnf` package.

Ideally, this plugin would be updated for DNF5, but in the meantime, it should depend on `python3-dnf` rather than `dnf`. `dnf5` and `python3-dnf`  can be installed simultaneously and thus not break upgrading to Fedora 39, but `dnf5` and `dnf` conflict.

`dnf` only provides the `/usr/bin/dnf` binary whereas `python3-dnf` provides all of DNF's actual functionality, so it should be safe to swap out the dependency, unless `dnf-plugin-diff` actually depends on `/usr/bin/dnf` for some reason.